### PR TITLE
fix(npm): dist folder is missing when installing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.es.js",
-  "types": "./dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "./dist"
+    "dist/"
   ],
   "scripts": {
     "start": "siroc build --watch",
@@ -58,7 +58,8 @@
     "test": "run-s build lint test:unit",
     "test:unit": "jest",
     "commit": "git-cz",
-    "release": "dotenv release-it --"
+    "release": "dotenv release-it --",
+    "prepare": "siroc build"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix"


### PR DESCRIPTION
For the latest update (v1.0.0) I noticed that the install of the package is not successful and the `dist` folder is missing. I added the `prepare` script to let npm create the necessary files during the package install.

## Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)