### PR TITLE
refactor(user): remove getter & setter

### DIFF
--- a/docs/content/en/api/methods.md
+++ b/docs/content/en/api/methods.md
@@ -109,7 +109,7 @@ await strapi.delete('restaurants', 1, {
 
 - Returns `Promise<StrapiAuthenticationResponse>`
 
-Register a new [User](methods#setuseruser) & sets the [Token](methods#settokentoken).
+Register a new [User](properties#user) & sets the [Token](methods#settokentoken).
 
 ```js
 await strapi.register({ username: "", email: "", password: "" });
@@ -121,7 +121,7 @@ await strapi.register({ username: "", email: "", password: "" });
 
 - Returns `Promise<StrapiAuthenticationResponse>`
 
-Authenticate a [User](methods#setuseruser) & sets the [Token](methods#settokentoken).
+Authenticate a [User](properties#user) & sets the [Token](methods#settokentoken).
 
 ```js
 await strapi.login({ identifier: "", password: "" });
@@ -211,13 +211,19 @@ Set local data of the logged-in user
 strapi.setUser(user);
 ```
 
-<alert type="info">You can also use `strapi.user` in order to set user data and get it.</alert>
+<alert type="warning">
+
+This method is no longer supported in **v2.2.0 & newer** since `getter` & `setter` for `user` properties has been removed.
+
+</alert>
+
+<alert type="info">You can use `strapi.user` in order to set user data and get it.</alert>
 
 ### `fetchUser()`
 
 - Returns `Promise`
 
-You often need to fetch your user data. Use this method to fetch the current user from `/users/me` if a `JWT` is present in your [storage](options#store). It sets the [User](methods#setuseruser).
+You often need to fetch your user data. Use this method to fetch the current user from `/users/me` if a `JWT` is present in your [storage](options#store). It sets the [User](properties#user).
 
 ```js
 await strapi.fetchUser();

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -46,7 +46,7 @@ const defaults: StrapiDefaultOptions = {
 export class Strapi {
   public axios: AxiosInstance;
   public options: StrapiDefaultOptions;
-  private _user: StrapiUser = null;
+  public user: StrapiUser = null;
 
   /**
    * Strapi SDK Constructor
@@ -70,14 +70,6 @@ export class Strapi {
 
     // Synchronize token if already exist
     this.syncToken();
-  }
-
-  get user(): StrapiUser {
-    return this._user;
-  }
-
-  set user(user: StrapiUser) {
-    this._user = user;
   }
 
   /**
@@ -135,7 +127,7 @@ export class Strapi {
         data,
       });
     this.setToken(jwt);
-    this.setUser(user);
+    this.user = user;
     return { user, jwt };
   }
 
@@ -161,7 +153,7 @@ export class Strapi {
         }
       );
     this.setToken(jwt);
-    this.setUser(user);
+    this.user = user;
     return { user, jwt };
   }
 
@@ -199,7 +191,7 @@ export class Strapi {
         }
       );
     this.setToken(jwt);
-    this.setUser(user);
+    this.user = user;
     return { user, jwt };
   }
 
@@ -253,7 +245,7 @@ export class Strapi {
       }
     );
     this.setToken(jwt);
-    this.setUser(user);
+    this.user = user;
     return { user, jwt };
   }
 
@@ -263,7 +255,7 @@ export class Strapi {
    * @returns void
    */
   public logout(): void {
-    this.setUser(null);
+    this.user = null;
     this.removeToken();
   }
 
@@ -360,16 +352,6 @@ export class Strapi {
   }
 
   /**
-   * Define local data of the logged-in user
-   *
-   * @param  {StrapiUser} user - New user data
-   * @returns void
-   */
-  public setUser(user: StrapiUser): void {
-    this._user = user;
-  }
-
-  /**
    * Refresh local data of the logged-in user
    *
    * @returns Promise<StrapiUser>
@@ -377,12 +359,12 @@ export class Strapi {
   public async fetchUser(): Promise<StrapiUser> {
     try {
       const user = await this.request<StrapiUser>("get", "/users/me");
-      this.setUser(user);
+      this.user = user;
     } catch (e) {
       this.logout();
     }
 
-    return this._user;
+    return this.user;
   }
 
   /**
@@ -402,6 +384,7 @@ export class Strapi {
       }
     }
   }
+
   /**
    * Set token in Axios headers & in choosen storage
    *
@@ -417,6 +400,7 @@ export class Strapi {
         : Cookies.set(key, token, cookieOptions);
     }
   }
+
   /**
    * Remove token in Axios headers & in choosen storage (Cookies or Local)
    *

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,6 @@ describe("Creation of SDK instance", () => {
 
     expect(Object.getOwnPropertyNames(Object.getPrototypeOf(strapi))).toEqual([
       "constructor",
-      "user",
       "request",
       "login",
       "register",
@@ -24,7 +23,6 @@ describe("Creation of SDK instance", () => {
       "create",
       "update",
       "delete",
-      "setUser",
       "fetchUser",
       "syncToken",
       "setToken",
@@ -32,7 +30,7 @@ describe("Creation of SDK instance", () => {
     ]);
 
     expect(Object.getOwnPropertyNames(strapi)).toEqual([
-      "_user",
+      "user",
       "options",
       "axios",
     ]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other changes (could be a refactor, documentation change ect...)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Since `getter` & `setter` are not really useful (we always could update user thanks `strapi.user = newUser` or `strapi.setUser(newUser)`.
I decided to remove them & set `user` property public to be more readable

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)