### PR TITLE
Refactor/token handling

### DIFF
--- a/docs/content/en/api/methods.md
+++ b/docs/content/en/api/methods.md
@@ -229,21 +229,45 @@ You often need to fetch your user data. Use this method to fetch the current use
 await strapi.fetchUser();
 ```
 
+### `getToken()`
+
+<badge>v2.2.0+</badge>
+
+- Returns `string | null`
+
+Retrieve your JWT token from [chosen storage](options#store)
+
+```js
+strapi.getToken();
+```
+
 ### `setToken(token)`
 
-Set token in Axios headers as a `Bearer` JWT & store it in [chosen storage](options#store).
+Set your JWT token in Axios headers as a `Bearer` JWT & store it in [chosen storage](options#store).
 
 ```js
 strapi.setToken(token);
 ```
 
+<alert type="warning">
+
+Since **v2.2.0 & newer** it only set token in your chosen storage. We now use [axios interceptors](https://axios-http.com/docs/interceptors) to synchronize token in header.
+
+</alert>
+
 ### `removeToken()`
 
-Remove token from Axios headers & [chosen storage](options#store).
+Remove your JWT token from Axios headers & [chosen storage](options#store).
 
 ```js
 strapi.removeToken();
 ```
+
+<alert type="warning">
+
+Since **v2.2.0 & newer** it only set token in your chosen storage. We now use [axios interceptors](https://axios-http.com/docs/interceptors) to synchronize token in header.
+
+</alert>
 
 ## Extends
 

--- a/docs/content/en/api/properties.md
+++ b/docs/content/en/api/properties.md
@@ -9,17 +9,22 @@ category: "🖥 API"
 ## `user`
 
 This object contains details about authenticated user. You can access it using `strapi`.
+
 ```js
 // get
-strapi.user
+strapi.user;
 // set user data
-strapi.user.avatar = ''
+strapi.user.avatar = "";
 ```
 
 ## `axios`
 
 You have access to the axios instance thanks `strapi.axios`. It allow you to set new headers or extend it:
+
 ```js
 strapi.axios.defaults.headers.common["Authorization"] = `Bearer myToken`;
 ```
+
+Note that we use [axios interceptors](https://axios-http.com/docs/interceptors) in order to synchronize your JWT token in header.
+
 > See [Axios documentation](https://github.com/axios/axios)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,4 @@
 import Strapi from "../src";
-import Cookies from "js-cookie";
 
 describe("Creation of SDK instance", () => {
   test("Basic instance", () => {
@@ -24,7 +23,7 @@ describe("Creation of SDK instance", () => {
       "update",
       "delete",
       "fetchUser",
-      "syncToken",
+      "getToken",
       "setToken",
       "removeToken",
     ]);
@@ -34,35 +33,5 @@ describe("Creation of SDK instance", () => {
       "options",
       "axios",
     ]);
-  });
-
-  test("Instance with existing token in localStorage", () => {
-    window.localStorage.setItem("strapi_jwt", "XXX");
-    const strapi = new Strapi({
-      store: { key: "strapi_jwt", useLocalStorage: true },
-    });
-
-    expect(strapi.axios.defaults.headers.common["Authorization"]).toBe(
-      "Bearer XXX"
-    );
-
-    delete strapi.axios.defaults.headers.common["Authorization"];
-    window.localStorage.removeItem("strapi_jwt");
-  });
-
-  test("Instance with existing token in Cookies", () => {
-    Cookies.set("strapi_jwt", "XXX");
-    const strapi = new Strapi({
-      store: { key: "strapi_jwt" },
-    });
-
-    expect(strapi.axios.defaults.headers.common["Authorization"]).toBe(
-      "Bearer XXX"
-    );
-
-    expect(Cookies.get("strapi_jwt")).toBe("XXX");
-
-    delete strapi.axios.defaults.headers.common["Authorization"];
-    Cookies.remove("strapi_jwt");
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other changes (could be a refactor, documentation change ect...)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
We used to use a custom `syncToken` method in order to synchronize user JWT token when the SDK is instantiate.
It was great but it only synchronize during the first instantiation which is not really great if there are some changes in your storage.

I decided to remove this `syncToken` method and to implement a new way to synchronize it thanks [axios interceptors](https://axios-http.com/docs/interceptors). It will look into your storage at each request & populate the headers if a token is found.

A new method come with this change, `getToken` it will allow you to retrieve your token without considering choosing between your storage

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)