### PR TITLE
build: update the target to support webpack based frameworks

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,7 +24,7 @@ export default [
       }),
       commonjs({ include: /node_modules/ }),
       esbuild({
-        target: "esnext",
+        target: "es2018",
       }),
       json(),
     ],

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -9,7 +9,7 @@ import axios, {
 import defu from "defu";
 import qs from "qs";
 import Cookies from "js-cookie";
-import { cleanDoubleSlashes, joinURL } from "ufo";
+import ufo from "ufo";
 
 // Load custom types
 import type {
@@ -66,13 +66,13 @@ export class Strapi {
     // clean url & prefix
     this.options = {
       ..._options,
-      url: cleanDoubleSlashes(_options?.url),
-      prefix: cleanDoubleSlashes(_options?.prefix),
+      url: ufo.cleanDoubleSlashes(_options?.url),
+      prefix: ufo.cleanDoubleSlashes(_options?.prefix),
     };
 
     // create axios instance
     this.axios = axios.create({
-      baseURL: joinURL(this.options.url, this.options.prefix),
+      baseURL: ufo.joinURL(this.options.url, this.options.prefix),
       paramsSerializer: qs.stringify,
       ...this.options.axiosOptions,
     });
@@ -261,7 +261,12 @@ export class Strapi {
    * @returns string
    */
   public getProviderAuthenticationUrl(provider: StrapiAuthProvider): string {
-    return joinURL(this.options.url, this.options.prefix, "connect", provider);
+    return ufo.joinURL(
+      this.options.url,
+      this.options.prefix,
+      "connect",
+      provider
+    );
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["dom", "esnext"],
-    "target": "esnext",
+    "lib": ["dom", "ES2018"],
+    "target": "ES2018",
     "importHelpers": true,
     // output .d.ts declaration files for consumers
     "declaration": true,


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other changes (could be a refactor, documentation change ect...)

## Description

With new bundler some frameworks - especially webpack based - show some issues based on the new build target (esNext instead of es2018). This PR fix #179
