### PR TITLE
fix: Wrong update function

### DIFF
--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -372,8 +372,8 @@ export class Strapi {
     data: AxiosRequestConfig["data"],
     params?: StrapiBaseRequestParams
   ): Promise<StrapiResponse<T>> {
-    return this.request<StrapiResponse<T>>("put", `/${contentType}/${id}`, {
-      data: { data },
+    return this.request<StrapiResponse<T>>("put", `/${contentType}/${id}`, 
+      data,
       params,
     });
   }


### PR DESCRIPTION
the payload for update a collection not work with old schema.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other changes (could be a refactor, documentation change ect...)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
