### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/docs/content/3.going-further/2.integrations.md
+++ b/docs/content/3.going-further/2.integrations.md
@@ -47,7 +47,7 @@ Unlike **Nuxt 2**, you only need to set up a `plugin`, and then you can simply a
 
 ::code-group
   ```ts [~/plugins/strapi.js]
-  import { defineNuxtPlugin } from '#app'
+  import { defineNuxtPlugin } from '#imports'
   import Strapi from 'strapi-sdk-js'
 
   export default defineNuxtPlugin(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other changes (could be a refactor, documentation change ect...)

## Description

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
