### PR TITLE
Update to strapi v5

### DIFF
--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -324,16 +324,16 @@ export class Strapi {
    * Get a specific {content-type} entry
    *
    * @param  {string} contentType - Content type's name pluralized
-   * @param  {string|number} id - ID of entry
+   * @param  {string} documentId - ID of entry
    * @param  {StrapiBaseRequestParams} params? - Fields selection & Relations population
    * @returns Promise<StrapiResponse<T>>
    */
   public findOne<T>(
     contentType: string,
-    id: string | number,
+    documentId: string,
     params?: StrapiBaseRequestParams
   ): Promise<StrapiResponse<T>> {
-    return this.request<StrapiResponse<T>>("get", `/${contentType}/${id}`, {
+    return this.request<StrapiResponse<T>>("get", `/${contentType}/${documentId}`, {
       params,
     });
   }
@@ -361,18 +361,18 @@ export class Strapi {
    * Update a specific entry
    *
    * @param  {string} contentType - Content type's name pluralized
-   * @param  {string|number} id - ID of entry to be updated
+   * @param  {string} documentId - ID of entry to be updated
    * @param  {AxiosRequestConfig["data"]} data - New entry data
    * @param  {StrapiBaseRequestParams} params? - Fields selection & Relations population
    * @returns Promise<StrapiResponse<T>>
    */
   public update<T>(
     contentType: string,
-    id: string | number,
+    documentId: string,
     data: AxiosRequestConfig["data"],
     params?: StrapiBaseRequestParams
   ): Promise<StrapiResponse<T>> {
-    return this.request<StrapiResponse<T>>("put", `/${contentType}/${id}`, {
+    return this.request<StrapiResponse<T>>("put", `/${contentType}/${documentId}`, {
       data: { data },
       params,
     });
@@ -382,16 +382,16 @@ export class Strapi {
    * Delete en entry
    *
    * @param  {string} contentType - Content type's name pluralized
-   * @param  {string|number} id - ID of entry to be deleted
+   * @param  {string} documentId - ID of entry to be deleted
    * @param  {StrapiBaseRequestParams} params? - Fields selection & Relations population
    * @returns Promise<StrapiResponse<T>>
    */
   public delete<T>(
     contentType: string,
-    id: string | number,
+    documentId: string | number,
     params?: StrapiBaseRequestParams
   ): Promise<StrapiResponse<T>> {
-    return this.request<StrapiResponse<T>>("delete", `/${contentType}/${id}`, {
+    return this.request<StrapiResponse<T>>("delete", `/${contentType}/${documentId}`, {
       params,
     });
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -560,7 +560,7 @@ export interface StrapiRequestParams extends StrapiBaseRequestParams {
   sort?: string | Array<string>;
   pagination?: PaginationByOffset | PaginationByPage;
   filters?: Record<string, unknown>;
-  publicationState?: "live" | "preview";
+  state?: "draft" | "published";
   locale?: StrapiLocale;
 }
 
@@ -574,10 +574,35 @@ export interface StrapiError {
   };
 }
 
-export interface StrapiResponse<T> {
-  data: T;
-  meta: Record<string, unknown>;
+export interface StrapiSystemFields {
+  documentId: string;
+  locale?: string;
 }
+
+export type StrapiData<T> = T extends object
+  ? T extends Array<infer U>
+    ? Array<StrapiData<U>> // Handle arrays
+    : T extends Record<string, unknown>
+    ? { [K in keyof T]: StrapiData<T[K]> } & StrapiSystemFields
+    : T
+  : T;
+
+export interface StrapiResponse<T> {
+  data: StrapiData<T>;
+  meta: StrapiMeta;
+}
+
+// Pagination interface for optional pagination info in the meta field
+export interface Pagination {
+  page: number;
+  pageSize: number;
+}
+
+// Meta field can be Record<string, unknown> or optionally contain pagination info
+export interface StrapiMeta extends Record<string, unknown> {
+  pagination?: Pagination;
+}
+
 
 export interface StrapiAuthenticationResponse {
   user: Record<string, unknown>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -575,6 +575,8 @@ export interface StrapiError {
 }
 
 export interface StrapiSystemFields {
+  /** @deprecated use documentId instead */
+  id: number | string;
   documentId: string;
   locale?: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -579,28 +579,28 @@ export interface StrapiSystemFields {
   locale?: string;
 }
 
-export type StrapiData<T> = T extends object
+export type StrapiResponseData<T> = T extends object
   ? T extends Array<infer U>
-    ? Array<StrapiData<U>> // Handle arrays
+    ? Array<StrapiResponseData<U>> // Handle arrays
     : T extends Record<string, unknown>
-    ? { [K in keyof T]: StrapiData<T[K]> } & StrapiSystemFields
+    ? { [K in keyof T]: StrapiResponseData<T[K]> } & StrapiSystemFields
     : T
   : T;
 
 export interface StrapiResponse<T> {
-  data: StrapiData<T>;
-  meta: StrapiMeta;
+  data: StrapiResponseData<T>;
+  meta: StrapiResponseMeta;
 }
 
 // Pagination interface for optional pagination info in the meta field
-export interface Pagination {
+export interface StrapiResponseMetaPagination {
   page: number;
   pageSize: number;
 }
 
 // Meta field can be Record<string, unknown> or optionally contain pagination info
-export interface StrapiMeta extends Record<string, unknown> {
-  pagination?: Pagination;
+export interface StrapiResponseMeta extends Record<string, unknown> {
+  pagination?: StrapiResponseMetaPagination;
 }
 
 

--- a/test/lib/strapi.test.ts
+++ b/test/lib/strapi.test.ts
@@ -528,7 +528,7 @@ describe("Strapi SDK", () => {
     });
 
     test("findOne - Get a specific {content-type} entry", async () => {
-      await context.strapi.findOne("restaurants", 1, {
+      await context.strapi.findOne("restaurants", '1', {
         fields: ["name"],
       });
 
@@ -571,7 +571,7 @@ describe("Strapi SDK", () => {
     test("update - Update a {content-type} entry", async () => {
       await context.strapi.update(
         "restaurants",
-        1,
+        '1',
         {
           username: "La Fourchette",
         },


### PR DESCRIPTION
Small changes to indicate and follow strapi v5 update. 

IMO I would maybe update this as a v3 perhaps and go on to hold v2.x.x as strapi v4 support?

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other changes (could be a refactor, documentation change ect...)

## Description

Mainly just changed some naming conventions to reflect strapi v5 update. (id => documentId)
Update to the types to automatically include documentId and optional locale to any type passed to the StrapiResponse

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
