### PR TITLE
feat: add axios instance creator option

### DIFF
--- a/docs/content/2.api/2.options.md
+++ b/docs/content/2.api/2.options.md
@@ -68,7 +68,7 @@ Options to be passed to the [Axios instance](https://github.com/axios/axios#requ
 
 Axios instance creator where the `axiosOptions` and merged internal defaults are passed as the first parameter. This is helpful if you want to customise the axios instance. 
 
-For exaxmple, lets say we want to implement request caching using the [`axios-cache-interceptor`](https://axios-cache-interceptor.js.org/) package:
+For example, lets say we want to implement request caching using the [`axios-cache-interceptor`](https://axios-cache-interceptor.js.org/) package:
 
 ```ts
 import axios from "axios";

--- a/docs/content/2.api/2.options.md
+++ b/docs/content/2.api/2.options.md
@@ -60,3 +60,25 @@ const strapi = new Strapi({
 - Default: `{}`
 
 Options to be passed to the [Axios instance](https://github.com/axios/axios#request-config).
+
+### `axiosCreate`
+
+- Type: `AxiosStatic['create']`
+- Default: `(config) => axios.create(config)`
+
+Axios instance creator where the `axiosOptions` and merged internal defaults are passed as the first parameter. This is helpful if you want to customise the axios instance. 
+
+For exaxmple, lets say we want to implement request caching using the [`axios-cache-interceptor`](https://axios-cache-interceptor.js.org/) package:
+
+```ts
+import axios from "axios";
+import Strapi from "strapi-sdk-js"
+import { setupCache } from "axios-cache-interceptor"
+
+const strapi = new Strapi({
+  axiosCreate(config) {
+    const instance = axios.create(config)
+    return setupCache(instance)
+  }
+})
+```

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -43,6 +43,9 @@ const defaults: StrapiDefaultOptions = {
     cookieOptions: { path: "/" },
   },
   axiosOptions: {},
+  axiosCreate(instanceConfig) {
+    return axios.create(instanceConfig);
+  }
 };
 
 export class Strapi {
@@ -58,6 +61,7 @@ export class Strapi {
    * @param {string} options.url? - Your Strapi API URL, Default: http://localhost::1337
    * @param {StoreConfig} options.store? - Config the way you want to store JWT (Cookie or LocalStorage)
    * @param {AxiosRequestConfig} options.axiosOptions? - The list of your Content type on your Strapi API
+   * @param {Function} options.axiosCreate? - Axios instance creator function
    */
   constructor(options?: StrapiOptions) {
     // merge given options with default values
@@ -71,11 +75,11 @@ export class Strapi {
     };
 
     // create axios instance
-    this.axios = axios.create({
+    this.axios = this.options.axiosCreate({
       baseURL: joinURL(this.options.url, this.options.prefix),
       paramsSerializer: qs.stringify,
       ...this.options.axiosOptions,
-    });
+    })
 
     // Synchronize token before each request
     this.axios.interceptors.request.use((config) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosStatic } from "axios";
 import type { CookieAttributes } from "js-cookie";
 
 export type StrapiAuthProvider =
@@ -528,6 +528,7 @@ export interface StrapiOptions {
   prefix?: string;
   store?: StoreConfig;
   axiosOptions?: AxiosRequestConfig;
+  axiosCreate?: AxiosStatic['create']
 }
 
 export interface StrapiDefaultOptions {
@@ -535,6 +536,7 @@ export interface StrapiDefaultOptions {
   prefix: string;
   store: StoreConfig;
   axiosOptions: AxiosRequestConfig;
+  axiosCreate: AxiosStatic['create']
 }
 
 export type StrapiUser = Record<string, unknown> | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosStatic } from "axios";
+import { AxiosRequestConfig, AxiosStatic } from "axios";
 import type { CookieAttributes } from "js-cookie";
 
 export type StrapiAuthProvider =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Added `axiosCreate` option to customize the Axios instance

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other changes (could be a refactor, documentation change ect...)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR adds an `axiosCreate` option to the `Strapi` class, allowing users to customize the Axios instance.

This is useful for cases such as implementing request caching using the [`axios-cache-interceptor`](https://axios-cache-interceptor.js.org/) package, which requires passing the Axios instance to the setup function (see below). Previously, this was not possible due to the `axios.create` method being called in the constructor.

```ts
const instance = axios.create(config)
const axios = setupCache(instance)
```

With the new `axiosCreate` option, this can now be done as follows:

```ts
const strapi = new Strapi({
  axiosCreate(config) {
    const instance = axios.create(config)
    return setupCache(instance)
  }
})
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
