### PR TITLE
chore: document v3 Node engine support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "files": [
     "dist/"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "rollup -c --watch",
     "build": "rm -rf dist && rollup -c",


### PR DESCRIPTION
## Summary
- add package engines metadata for the v3/develop line
- document Node.js >=20 support for package consumers

## Notes
This does not change the Rollup/esbuild output target. The published SDK build remains targeted at ES2018.

## Validation
- yarn install