### PR TITLE
chore: document v2 Node engine support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "files": [
     "dist/"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "start": "rollup -c --watch",
     "build": "rm -rf dist && rollup -c",


### PR DESCRIPTION
## Summary
- add package engines metadata for the v2 maintenance line
- document Node.js >=16 support for package consumers

## Notes
This does not change the Rollup/esbuild output target.

## Validation
- yarn install --ignore-scripts

Lifecycle scripts were skipped for validation because this v2 branch still uses the older Rollup config JSON import assertion, which is addressed separately in the v2 security dependency PR.