### PR TITLE
chore(config): update publish and tsconfig settings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,8 @@ test/
 docs/
 example/
 scripts/
+coverage/
+commitlint.config.js
+husky.config.js
+jest.config.js
 .eslintrc.js
-.commitlint.config.js
-.husky.config.js
-.jest.config.js

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "email": "thibautdavid@icloud.com",
     "url": "https://thibautdavid.com"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
   "maintainers": [
     {
       "name": "Thibaut DAVID",
@@ -90,6 +93,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@types/jest": "27.5.2",
+    "@types/node": "^25.9.1",
     "@types/sinon": "10.0.20",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,7 @@
     "noEmit": true,
     // Resolve json module
     "resolveJsonModule": true
-  }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["docs", "test", "dist", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
   integrity sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==
 
+"@types/node@^25.9.1":
+  version "25.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
+  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -7302,6 +7309,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What changed
- add npm publish registry config
- add @types/node and sync the lockfile
- scope the root tsconfig to src and exclude docs/test output paths

## Why
- ensure package publishing targets the npm registry
- satisfy node typing needs in tooling
- stop the root TypeScript config from pulling docs files into the SDK program

## Validation
- npx tsc --noEmit -p tsconfig.json
- yarn build