### PR TITLE
fix(types): extend pagination response metadata

### DIFF
--- a/docs/content/2.api/4.types.md
+++ b/docs/content/2.api/4.types.md
@@ -129,7 +129,7 @@ type StrapiLocale = | "af" | "af-NA" | "af-ZA" | "agq" ...
 ```ts
 interface StrapiResponse<T> {
   data: T & StrapiSystemFields
-  meta: Record<string, unknown>
+  meta: StrapiResponseMeta
 }
 
 interface StrapiSystemFields {
@@ -137,9 +137,46 @@ interface StrapiSystemFields {
   id: integer
   documentId: string
 }
+
+interface StrapiResponseMeta extends Record<string, unknown> {
+  pagination?: StrapiResponseMetaPagination
+}
+
+interface StrapiResponseMetaPagination {
+  page: number
+  pageSize: number
+  start: number
+  limit: number
+  pageCount?: number
+  total?: number
+}
 ```
 
+`meta` can include pagination information. See [`StrapiResponseMetaPagination`](#StrapiResponseMetaPagination) below.
+
 > Check out the [Strapi Requests documentation](https://docs.strapi.io/dev-docs/api/rest#requests) for more information.
+
+### `StrapiResponseMetaPagination`
+
+Pagination metadata returned in `response.meta.pagination`.
+
+```ts
+interface StrapiResponseMetaPagination {
+  page: number
+  pageSize: number
+  start: number
+  limit: number
+  pageCount?: number
+  total?: number
+}
+```
+
+This SDK exposes all pagination keys in a single type for backward compatibility and autocomplete convenience.
+
+- page-based pagination uses `page`, `pageSize`, and optionally `pageCount` and `total`
+- offset-based pagination uses `start`, `limit`, and optionally `total`
+
+> Check out the [Strapi Pagination documentation](https://docs.strapi.io/cms/api/rest/sort-pagination) for more information.
 
 ### `StrapiError`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export type {
   StrapiRequestParams,
   StrapiResetPasswordData,
   StrapiResponse,
+  StrapiResponseMeta,
+  StrapiResponseMetaPagination,
   StrapiUser,
 } from "./lib/types";
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -596,10 +596,13 @@ export interface StrapiResponse<T> {
   meta: StrapiResponseMeta;
 }
 
-// Pagination interface for optional pagination info in the meta field
 export interface StrapiResponseMetaPagination {
   page: number;
   pageSize: number;
+  start: number;
+  limit: number;
+  pageCount?: number;
+  total?: number;
 }
 
 // Meta field can be Record<string, unknown> or optionally contain pagination info


### PR DESCRIPTION
## Summary

This updates the SDK pagination response metadata typing and documentation.

- extend `StrapiResponseMetaPagination` to include the missing pagination metadata fields
- export `StrapiResponseMeta` and `StrapiResponseMetaPagination`
- document the pagination metadata shape in the types docs

## Why

Strapi pagination metadata differs depending on page-based or offset-based pagination. The SDK type was missing fields that are documented by Strapi and did not expose the pagination metadata type clearly in the docs.

For compatibility, the SDK now exposes a single pagination metadata type that includes all pagination keys, with `pageCount` and `total` optional.

## Validation

- `yarn build`
- `yarn lint`

fix #213 