### PR TITLE
fix(delete): allow locale param for collection document deletion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type {
   StrapiForgotPasswordData,
   StrapiChangePasswordData,
   StrapiLocale,
+  StrapiDeleteRequestParams,
   StrapiOptions,
   StrapiRegistrationData,
   StrapiRequestParams,

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -17,6 +17,7 @@ import type {
   StrapiAuthenticationResponse,
   StrapiAuthProvider,
   StrapiBaseRequestParams,
+  StrapiDeleteRequestParams,
   StrapiDefaultOptions,
   StrapiEmailConfirmationData,
   StrapiError,
@@ -389,14 +390,22 @@ export class Strapi {
   }
 
   /**
-   * Delete en entry
+   * Delete an entry
    *
    * @param  {string} contentType - Content type's name pluralized
    * @param  {string} documentId - documentId of entry to be deleted
+   * @param  {StrapiDeleteRequestParams} params? - Delete-specific query parameters
    * @returns Promise<void>
    */
-  public delete(contentType: string, documentId: string): Promise<void> {
-    return this.request("delete", `/${contentType}/${documentId}`);
+  public delete(
+    contentType: string,
+    documentId: string,
+    params?: StrapiDeleteRequestParams
+  ): Promise<void> {
+    return this.request("delete", `/${contentType}/${documentId}`, {
+      params,
+    }
+  );
   }
 
   /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -556,6 +556,10 @@ export interface StrapiBaseRequestParams {
   populate?: string | Array<string> | Record<string, unknown>;
 }
 
+export interface StrapiDeleteRequestParams {
+  locale?: StrapiLocale;
+}
+
 export interface StrapiRequestParams extends StrapiBaseRequestParams {
   sort?: string | Array<string>;
   pagination?: PaginationByOffset | PaginationByPage;

--- a/test/lib/strapi.test.ts
+++ b/test/lib/strapi.test.ts
@@ -603,6 +603,25 @@ describe("Strapi SDK", () => {
         context.axiosRequest.calledWithExactly({
           method: "delete",
           url: "/restaurants/hgv1vny5cebq2l3czil1rpb3",
+          params: undefined,
+        })
+      ).toBe(true);
+    });
+
+    test("delete - Delete a localized {content-type} entry", async () => {
+      await context.strapi.delete(
+        "restaurants",
+        "hgv1vny5cebq2l3czil1rpb3",
+        { locale: "fr" }
+      );
+
+      expect(
+        context.axiosRequest.calledWithExactly({
+          method: "delete",
+          url: "/restaurants/hgv1vny5cebq2l3czil1rpb3",
+          params: {
+            locale: "fr",
+          },
         })
       ).toBe(true);
     });


### PR DESCRIPTION
## What changed
- adds a public StrapiDeleteRequestParams type
- updates strapi.delete(contentType, documentId, params?) to forward delete query params
- adds test coverage for localized collection document deletion

## Why
Strapi v5 documents the locale query parameter for REST DELETE requests when deleting a specific localized version of a collection document. The SDK previously exposed no way to pass that parameter.

## Scope
This change is intentionally limited to collection document deletion:
- supported: delete(contentType, documentId, { locale })
- not added in this PR: single-type delete overloads

Single-type support is being left for a later change to avoid changing the runtime interpretation of a non-string second argument and risking behavior changes in existing applications.

## Validation
- yarn test:unit --watchman=false --runInBand test/lib/strapi.test.ts

fix #219 