### PR TITLE
fix(auth): store token in non-browser environments

### DIFF
--- a/docs/content/2.api/1.methods.md
+++ b/docs/content/2.api/1.methods.md
@@ -271,7 +271,7 @@ const user = await strapi.fetchUser()
 
 - **Returns:** `string | null`
 
-Retrieve your JWT token from selected [storage](options#store).
+Retrieve your JWT token from the selected [storage](options#store). In non-browser environments, this returns the token stored in memory on the SDK instance.
 
 ```ts
 const token = strapi.getToken()
@@ -283,7 +283,7 @@ const token = strapi.getToken()
   - token: `string`
 - **Returns:** `void`
 
-Set your JWT token in `axios` headers as a `Bearer` token and store it in the selected [storage](options#store).
+Store your JWT token in the selected [storage](options#store). Requests automatically use the stored token as a `Bearer` token through the SDK's request interceptor.
 
 ```ts
 const token = strapi.setToken('my_jwt_token')
@@ -293,7 +293,7 @@ const token = strapi.setToken('my_jwt_token')
 
 - **Returns:** `void`
 
-Remove your JWT token from `axios` headers and the selected [storage](options#store).
+Remove your JWT token from the selected [storage](options#store). In non-browser environments, this clears the token stored in memory on the SDK instance.
 
 ```ts
 strapi.removeToken()

--- a/docs/content/2.api/2.options.md
+++ b/docs/content/2.api/2.options.md
@@ -38,6 +38,8 @@ You have the capability to modify the API endpoint `prefix`. The default `prefix
 
 The store's configuration allows you to set the `key` for the cookie name, as well as the localStorage key if you choose to use it thanks the `useLocalStorage` boolean property. Additionally, you can provide `cookieOptions` to be passed to the [js-cookie](https://github.com/jshttp/cookie#options-1) package.
 
+In non-browser environments, such as Node.js or SSR, cookies and localStorage are not available. In that case, the SDK stores the token in memory on the SDK instance after calling `setToken`. Avoid reusing the same authenticated SDK instance across multiple users or SSR requests, otherwise one user's token could be reused for another request.
+
 ```ts
 import Strapi from "strapi-sdk-js"
 

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -49,6 +49,7 @@ export class Strapi {
   public axios: AxiosInstance;
   public options: StrapiDefaultOptions;
   public user: StrapiUser = null;
+  private _token: string | null = null;
 
   /**
    * Strapi SDK Constructor
@@ -426,17 +427,15 @@ export class Strapi {
    */
   public getToken(): string | null {
     const { useLocalStorage, key } = this.options.store;
-    if (isBrowser()) {
-      const token = useLocalStorage
-        ? window.localStorage.getItem(key)
-        : (Cookies.get(key) as string);
+    if (!isBrowser()) return this._token;
 
-      if (typeof token === "undefined") return null;
+    const token = useLocalStorage
+      ? window.localStorage.getItem(key)
+      : (Cookies.get(key) as string);
 
-      return token;
-    }
+    if (typeof token === "undefined") return null;
 
-    return null;
+    return token;
   }
 
   /**
@@ -447,11 +446,14 @@ export class Strapi {
    */
   public setToken(token: string): void {
     const { useLocalStorage, key, cookieOptions } = this.options.store;
-    if (isBrowser()) {
-      useLocalStorage
-        ? window.localStorage.setItem(key, token)
-        : Cookies.set(key, token, cookieOptions);
+    if (!isBrowser()) {
+      this._token = token;
+      return;
     }
+
+    useLocalStorage
+      ? window.localStorage.setItem(key, token)
+      : Cookies.set(key, token, cookieOptions);
   }
 
   /**
@@ -461,10 +463,11 @@ export class Strapi {
    */
   public removeToken(): void {
     const { useLocalStorage, key } = this.options.store;
-    if (isBrowser()) {
-      useLocalStorage
-        ? window.localStorage.removeItem(key)
-        : Cookies.remove(key);
+    if (!isBrowser()) {
+      this._token = null;
+      return;
     }
+
+    useLocalStorage ? window.localStorage.removeItem(key) : Cookies.remove(key);
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,7 +34,7 @@ describe("Creation of SDK instance", () => {
     );
 
     expect(Object.getOwnPropertyNames(strapi).sort()).toEqual(
-      ["user", "options", "axios"].sort()
+      ["user", "options", "axios", "_token"].sort()
     );
   });
 

--- a/test/lib/strapi.test.ts
+++ b/test/lib/strapi.test.ts
@@ -460,6 +460,49 @@ describe("Strapi SDK", () => {
       windowSpy.mockRestore();
     });
 
+    test("Set and remove Token in non DOM env", () => {
+      const windowSpy = jest.spyOn(window, "window", "get");
+      // @ts-ignore
+      windowSpy.mockImplementation(() => undefined);
+
+      context.strapi.setToken("XXX");
+      expect(context.strapi.getToken()).toBe("XXX");
+
+      context.strapi.removeToken();
+      expect(context.strapi.getToken()).toBe(null);
+
+      windowSpy.mockRestore();
+    });
+
+    test("Set Token authenticates requests in non DOM env", async () => {
+      const windowSpy = jest.spyOn(window, "window", "get");
+      // @ts-ignore
+      windowSpy.mockImplementation(() => undefined);
+
+      const strapi = new Strapi({
+        url: "http://strapi-host/",
+        axiosOptions: {
+          adapter: async (config) => ({
+            config,
+            data: config.headers,
+            headers: {},
+            status: 200,
+            statusText: "OK",
+          }),
+        },
+      });
+
+      strapi.setToken("XXX");
+      const headers = await strapi.request<Record<string, string>>(
+        "get",
+        "/users/me"
+      );
+
+      expect(headers.Authorization).toBe("Bearer XXX");
+
+      windowSpy.mockRestore();
+    });
+
     test("Get Token from Cookies", () => {
       Cookies.set("strapi_jwt", "XXX");
 


### PR DESCRIPTION
## Summary

- Store JWTs in memory on the SDK instance when running outside the browser.
- Keep existing cookie and localStorage behavior unchanged in browser environments.
- Add tests for non-DOM token set/get/remove behavior and request interceptor authentication.

## Validation

- yarn lint
- yarn test:unit --runInBand --no-watchman
- yarn build

fix #216 