### PR TITLE
docs: add version badges to new API docs

### DIFF
--- a/docs/content/2.api/1.methods.md
+++ b/docs/content/2.api/1.methods.md
@@ -117,13 +117,21 @@ Update a content type entry by its documentId, and receive the updated entry in 
 - **Parameters**
   - contentType: `string`
   - documentId: `string`
+  - params?: [`StrapiDeleteRequestParams`](types#strapideleterequestparams) :badge[v3.0.2+]
 - **Returns:** [`Promise<void>`]
 
-Delete a content type entry by its documentId
+Delete a content type entry by its documentId. You can pass delete-specific query parameters such as `locale`.
 
-```ts
-  await strapi.delete<Restaurant>('restaurants', 'hgv1vny5cebq2l3czil1rpb3')
+::code-group
+  ```ts [Minimal]
+  await strapi.delete('restaurants', 'hgv1vny5cebq2l3czil1rpb3')
   ```
+  ```ts [With parameters]
+  await strapi.delete('restaurants', 'hgv1vny5cebq2l3czil1rpb3', {
+    locale: 'en',
+  })
+  ```
+::
 
 ::alert{type=warning}
 With **Strapi v5**, `DELETE` requests only send a 204 HTTP status on success and no longer return data in the response body.
@@ -271,7 +279,7 @@ const user = await strapi.fetchUser()
 
 - **Returns:** `string | null`
 
-Retrieve your JWT token from the selected [storage](options#store). In non-browser environments, this returns the token stored in memory on the SDK instance.
+Retrieve your JWT token from the selected [storage](options#store). In non-browser environments, this returns the token stored in memory on the SDK instance. :badge[v3.0.2+]
 
 ```ts
 const token = strapi.getToken()
@@ -283,7 +291,7 @@ const token = strapi.getToken()
   - token: `string`
 - **Returns:** `void`
 
-Store your JWT token in the selected [storage](options#store). Requests automatically use the stored token as a `Bearer` token through the SDK's request interceptor.
+Store your JWT token in the selected [storage](options#store). Requests automatically use the stored token as a `Bearer` token through the SDK's request interceptor. Non-browser environments store it in memory on the SDK instance. :badge[v3.0.2+]
 
 ```ts
 const token = strapi.setToken('my_jwt_token')
@@ -293,7 +301,7 @@ const token = strapi.setToken('my_jwt_token')
 
 - **Returns:** `void`
 
-Remove your JWT token from the selected [storage](options#store). In non-browser environments, this clears the token stored in memory on the SDK instance.
+Remove your JWT token from the selected [storage](options#store). In non-browser environments, this clears the token stored in memory on the SDK instance. :badge[v3.0.2+]
 
 ```ts
 strapi.removeToken()

--- a/docs/content/2.api/2.options.md
+++ b/docs/content/2.api/2.options.md
@@ -38,7 +38,9 @@ You have the capability to modify the API endpoint `prefix`. The default `prefix
 
 The store's configuration allows you to set the `key` for the cookie name, as well as the localStorage key if you choose to use it thanks the `useLocalStorage` boolean property. Additionally, you can provide `cookieOptions` to be passed to the [js-cookie](https://github.com/jshttp/cookie#options-1) package.
 
-In non-browser environments, such as Node.js or SSR, cookies and localStorage are not available. In that case, the SDK stores the token in memory on the SDK instance after calling `setToken`. Avoid reusing the same authenticated SDK instance across multiple users or SSR requests, otherwise one user's token could be reused for another request.
+In non-browser environments, such as Node.js or SSR, cookies and localStorage are not available. In that case, the SDK stores the token in memory on the SDK instance after calling `setToken`. :badge[v3.0.2+]
+
+Avoid reusing the same authenticated SDK instance across multiple users or SSR requests, otherwise one user's token could be reused for another request.
 
 ```ts
 import Strapi from "strapi-sdk-js"

--- a/docs/content/2.api/4.types.md
+++ b/docs/content/2.api/4.types.md
@@ -68,6 +68,20 @@ interface StrapiBaseRequestParams {
 
 > Check out the [Strapi REST API documentation](https://docs.strapi.io/dev-docs/api/rest/parameters) for more information.
 
+### `StrapiDeleteRequestParams`
+
+:badge[v3.0.2+]
+
+Strapi query parameters used in [delete](methods#delete) methods.
+
+```ts
+interface StrapiDeleteRequestParams {
+  locale?: StrapiLocale
+}
+```
+
+> Check out the [Strapi i18n documentation](https://docs.strapi.io/cms/api/rest/locale#delete-a-document) for more information.
+
 ### `StrapiRequestParams`
 
 Strapi query filters used in [find](methods#find) methods.
@@ -152,9 +166,19 @@ interface StrapiResponseMetaPagination {
 }
 ```
 
-`meta` can include pagination information. See [`StrapiResponseMetaPagination`](#StrapiResponseMetaPagination) below.
+`meta` can include pagination information. See [`StrapiResponseMeta`](#StrapiResponseMeta) and [`StrapiResponseMetaPagination`](#StrapiResponseMetaPagination) below.
 
 > Check out the [Strapi Requests documentation](https://docs.strapi.io/dev-docs/api/rest#requests) for more information.
+
+### `StrapiResponseMeta`
+
+Metadata returned in `response.meta`.
+
+```ts
+interface StrapiResponseMeta extends Record<string, unknown> {
+  pagination?: StrapiResponseMetaPagination
+}
+```
 
 ### `StrapiResponseMetaPagination`
 


### PR DESCRIPTION
## Summary

Adds version badges to the newly documented API surfaces so readers can see which SDK version introduced them.

## Changes

- Tags the new delete params documentation with :badge[v3.0.2+].
- Tags SSR/non-browser token storage behavior for store, getToken, setToken, and removeToken.
- Documents and tags StrapiDeleteRequestParams.

## Validation

- yarn --cwd docs build