### PR TITLE
fix(types): handle array response system fields

### DIFF
--- a/docs/content/2.api/4.types.md
+++ b/docs/content/2.api/4.types.md
@@ -142,9 +142,13 @@ type StrapiLocale = | "af" | "af-NA" | "af-ZA" | "agq" ...
 
 ```ts
 interface StrapiResponse<T> {
-  data: T & StrapiSystemFields
+  data: StrapiResponseData<T>
   meta: StrapiResponseMeta
 }
+
+type StrapiResponseData<T> = T extends Array<infer U>
+  ? Array<StrapiResponseData<U>>
+  : T & StrapiSystemFields
 
 interface StrapiSystemFields {
   // @deprecated use documentId instead

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -596,7 +596,7 @@ export type StrapiResponseData<T> = T extends undefined | null
   : T;
 
 export interface StrapiResponse<T> {
-  data: StrapiResponseData<T> & StrapiSystemFields; // Ensure data always includes system fields
+  data: StrapiResponseData<T>;
   meta: StrapiResponseMeta;
 }
 

--- a/test/lib/types.test.ts
+++ b/test/lib/types.test.ts
@@ -1,0 +1,37 @@
+import type { StrapiResponse } from "../../src";
+
+type DataType = {
+  stringField: string;
+};
+
+describe("Strapi response types", () => {
+  test("allows system fields on array elements", () => {
+    const response: StrapiResponse<DataType[]> = {
+      data: [
+        {
+          stringField: "testString1",
+          id: 1,
+          documentId: "awe89uawe09iwd",
+        },
+      ],
+      meta: {},
+    };
+
+    expect(response.data[0].id).toBe(1);
+    expect(response.data[0].documentId).toBe("awe89uawe09iwd");
+  });
+
+  test("allows system fields on a single document", () => {
+    const response: StrapiResponse<DataType> = {
+      data: {
+        stringField: "testString1",
+        id: 1,
+        documentId: "awe89uawe09iwd",
+      },
+      meta: {},
+    };
+
+    expect(response.data.id).toBe(1);
+    expect(response.data.documentId).toBe("awe89uawe09iwd");
+  });
+});


### PR DESCRIPTION
Fixes #222

This updates StrapiResponse<T> so array responses keep system fields on each element instead of incorrectly intersecting id and documentId onto the array itself. That restores the expected type for StrapiResponse<T[]> while preserving the single-document shape.

Checks:
- yarn build
- yarn lint
- yarn test:unit --runInBand --no-watchman

fix #222 